### PR TITLE
Add Swift example

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,7 +63,7 @@ jobs:
       - run:
           name: External dependencies
           command: |
-            sudo apt-get install -y default-jdk g++ gcc valgrind
+            sudo apt-get install -y clang default-jdk g++ gcc libicu-dev libtinfo5 valgrind
       - run:
           name: Cbindgen
           command: |
@@ -85,6 +85,7 @@ jobs:
       - run: OUT_DIR=/tmp/cpp ./.circleci/test_cpp.sh
       - run: OUT_DIR=/tmp/java ./.circleci/test_java.sh
       - run: OUT_DIR=/tmp/kotlin ./.circleci/test_kotlin.sh
+      - run: OUT_DIR=/tmp/swift ./.circleci/test_swift.sh
 
   tests_wasm:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,11 +61,26 @@ jobs:
       - checkout
       - restore-sccache-cache
       - run:
-          name: Initial configuration
+          name: External dependencies
           command: |
-            sudo apt-get install -y default-jdk g++ gcc valgrind snapd
+            sudo apt-get install -y default-jdk g++ gcc valgrind
+      - run:
+          name: Cbindgen
+          command: |
+            cd signer-ffi
             rustup install nightly
-            cargo +nightly install cbindgen
+            rustup default nightly
+            cargo install cbindgen
+            cbindgen --config cbindgen.toml --crate filecoin-signer-ffi --lang c --output /tmp/filecoin_signer_ffi.h
+            cbindgen --config cbindgen.toml --crate filecoin-signer-ffi --lang c++ --output /tmp/filecoin_signer_ffi_cpp.h
+      - run:
+          name: Libraries
+          command: |
+            cd signer-ffi
+            cargo build
+            cp ../target/debug/libfilecoin_signer_ffi.so /tmp/libfilecoin_signer_ffi.so
+            cargo build --features with-jni
+            cp ../target/debug/libfilecoin_signer_ffi.so /tmp/libfilecoin_signer_ffi_java.so
       - run: OUT_DIR=/tmp/c ./.circleci/test_c.sh
       - run: OUT_DIR=/tmp/cpp ./.circleci/test_cpp.sh
       - run: OUT_DIR=/tmp/java ./.circleci/test_java.sh

--- a/.circleci/test_c.sh
+++ b/.circleci/test_c.sh
@@ -1,10 +1,8 @@
-cd signer-ffi
 mkdir $OUT_DIR
-cp -r ../examples/ffi/c/* $OUT_DIR
-rustup default nightly
-cbindgen --config cbindgen.toml --crate filecoin-signer-ffi --lang c --output $OUT_DIR/filecoin_signer_ffi.h
-cargo build
-cp ../target/debug/libfilecoin_signer_ffi.so $OUT_DIR
-( cd $OUT_DIR; gcc main.c -L. -lfilecoin_signer_ffi -o main )
-LD_LIBRARY_PATH=$OUT_DIR $OUT_DIR/main
-LD_LIBRARY_PATH=$OUT_DIR valgrind --leak-check=full --show-leak-kinds=all --track-origins=yes --verbose $OUT_DIR/main
+cp -r ./examples/ffi/c/* $OUT_DIR
+cd $OUT_DIR;
+cp /tmp/filecoin_signer_ffi.h .
+cp /tmp/libfilecoin_signer_ffi.so .
+gcc main.c -L. -lfilecoin_signer_ffi -o ./main
+LD_LIBRARY_PATH=. ./main
+LD_LIBRARY_PATH=. valgrind --leak-check=full --show-leak-kinds=all --track-origins=yes --verbose ./main

--- a/.circleci/test_cpp.sh
+++ b/.circleci/test_cpp.sh
@@ -1,10 +1,8 @@
-cd signer-ffi
 mkdir $OUT_DIR
-cp -r ../examples/ffi/c++/* $OUT_DIR
-rustup default nightly
-cbindgen --config cbindgen.toml --crate filecoin-signer-ffi --lang c++ --output $OUT_DIR/filecoin_signer_ffi.h
-cargo build
-cp ../target/debug/libfilecoin_signer_ffi.so $OUT_DIR
-( cd $OUT_DIR; g++ main.cpp -L. -lfilecoin_signer_ffi -o main )
-LD_LIBRARY_PATH=$OUT_DIR $OUT_DIR/main
-LD_LIBRARY_PATH=$OUT_DIR valgrind --leak-check=full --show-leak-kinds=all --track-origins=yes --verbose $OUT_DIR/main
+cp -r ./examples/ffi/c++/* $OUT_DIR
+cd $OUT_DIR
+cp /tmp/filecoin_signer_ffi_cpp.h ./filecoin_signer_ffi.h
+cp /tmp/libfilecoin_signer_ffi.so .
+g++ main.cpp -L. -lfilecoin_signer_ffi -o ./main
+LD_LIBRARY_PATH=. ./main
+LD_LIBRARY_PATH=. valgrind --leak-check=full --show-leak-kinds=all --track-origins=yes --verbose ./main

--- a/.circleci/test_java.sh
+++ b/.circleci/test_java.sh
@@ -1,10 +1,10 @@
-cd signer-ffi
 mkdir $OUT_DIR
-cp -r ../examples/ffi/java/* $OUT_DIR
-cp -r java/* $OUT_DIR
-javac -h $OUT_DIR java/src/main/java/ch/zondax/FilecoinSigner.java 
-cargo build --features with-jni
-cp ../target/debug/libfilecoin_signer_ffi.so $OUT_DIR
-javac -d $OUT_DIR $OUT_DIR/src/main/java/ch/zondax/FilecoinSigner.java
-javac -cp $OUT_DIR $OUT_DIR/Main.java
-( cd $OUT_DIR; java -Djava.library.path="." -ea Main )
+cp -r ./examples/ffi/java/* $OUT_DIR
+cp -r ./signer-ffi/java/* $OUT_DIR
+cd $OUT_DIR
+cp /tmp/filecoin_signer_ffi.h .
+cp /tmp/libfilecoin_signer_ffi_java.so ./libfilecoin_signer_ffi.so
+javac -h . ./java/src/main/java/ch/zondax/FilecoinSigner.java 
+javac -d . ./src/main/java/ch/zondax/FilecoinSigner.java
+javac -cp . ./Main.java
+java -Djava.library.path="." -ea Main

--- a/.circleci/test_java.sh
+++ b/.circleci/test_java.sh
@@ -4,7 +4,6 @@ cp -r ./signer-ffi/java/* $OUT_DIR
 cd $OUT_DIR
 cp /tmp/filecoin_signer_ffi.h .
 cp /tmp/libfilecoin_signer_ffi_java.so ./libfilecoin_signer_ffi.so
-javac -h . ./java/src/main/java/ch/zondax/FilecoinSigner.java 
-javac -d . ./src/main/java/ch/zondax/FilecoinSigner.java
+javac -d . -h . ./src/main/java/ch/zondax/FilecoinSigner.java 
 javac -cp . ./Main.java
 java -Djava.library.path="." -ea Main

--- a/.circleci/test_kotlin.sh
+++ b/.circleci/test_kotlin.sh
@@ -9,7 +9,6 @@ cp -r ./signer-ffi/java/* $OUT_DIR
 cd $OUT_DIR
 cp /tmp/filecoin_signer_ffi.h .
 cp /tmp/libfilecoin_signer_ffi_java.so ./libfilecoin_signer_ffi.so
-javac -h . ./java/src/main/java/ch/zondax/FilecoinSigner.java 
-javac -d . ./src/main/java/ch/zondax/FilecoinSigner.java
+javac -d . -h . ./src/main/java/ch/zondax/FilecoinSigner.java 
 kotlinc -cp . ./Main.kt -include-runtime -d .
 kotlin -Djava.library.path="." -J-ea MainKt

--- a/.circleci/test_kotlin.sh
+++ b/.circleci/test_kotlin.sh
@@ -3,13 +3,13 @@ bash sdk.install.sh
 . ~/.sdkman/bin/sdkman-init.sh
 sdk install kotlin
 
-cd signer-ffi
 mkdir $OUT_DIR
-cp -r ../examples/ffi/kotlin/* $OUT_DIR
-cp -r java/* $OUT_DIR
-javac -h $OUT_DIR java/src/main/java/ch/zondax/FilecoinSigner.java 
-cargo build --features with-jni
-cp ../target/debug/libfilecoin_signer_ffi.so $OUT_DIR
-javac -d $OUT_DIR $OUT_DIR/src/main/java/ch/zondax/FilecoinSigner.java
-kotlinc -cp $OUT_DIR $OUT_DIR/Main.kt -include-runtime -d $OUT_DIR
-( cd $OUT_DIR; kotlin -Djava.library.path="." -J-ea MainKt )
+cp -r ./examples/ffi/kotlin/* $OUT_DIR
+cp -r ./signer-ffi/java/* $OUT_DIR
+cd $OUT_DIR
+cp /tmp/filecoin_signer_ffi.h .
+cp /tmp/libfilecoin_signer_ffi_java.so ./libfilecoin_signer_ffi.so
+javac -h . ./java/src/main/java/ch/zondax/FilecoinSigner.java 
+javac -d . ./src/main/java/ch/zondax/FilecoinSigner.java
+kotlinc -cp . ./Main.kt -include-runtime -d .
+kotlin -Djava.library.path="." -J-ea MainKt

--- a/.circleci/test_swift.sh
+++ b/.circleci/test_swift.sh
@@ -1,0 +1,11 @@
+wget https://swift.org/builds/swift-5.2.1-release/ubuntu1804/swift-5.2.1-RELEASE/swift-5.2.1-RELEASE-ubuntu18.04.tar.gz
+tar xzf swift-5.2.1-RELEASE-ubuntu18.04.tar.gz
+mv swift-5.2.1-RELEASE-ubuntu18.04 ~/.swift
+
+mkdir $OUT_DIR
+cp -r ./examples/ffi/swift/* $OUT_DIR
+cd $OUT_DIR;
+cp /tmp/filecoin_signer_ffi.h .
+cp /tmp/libfilecoin_signer_ffi.so .
+~/.swift/usr/bin/swiftc -import-objc-header filecoin_signer_ffi.h main.swift libfilecoin_signer_ffi.so -o ./main
+LD_LIBRARY_PATH=. ./main

--- a/examples/ffi/swift/README.md
+++ b/examples/ffi/swift/README.md
@@ -1,0 +1,12 @@
+# Swift bindingds
+
+To use this example, download the latest header and library or compile the `signer-ffi` directory.
+
+# Running
+
+Assuming that the header and library are in the same directory.
+
+```bash
+swiftc -import-objc-header filecoin_signer_ffi.h main.swift libfilecoin_signer_ffi.so -o ./main
+LD_LIBRARY_PATH=. ./main
+```

--- a/examples/ffi/swift/main.swift
+++ b/examples/ffi/swift/main.swift
@@ -1,0 +1,19 @@
+let error = filecoin_signer_error_new();
+let extended_key = filecoin_signer_key_derive(
+    "equip will roof matter pink blind book anxiety banner elbow sun young",
+    "m/44'/461'/0/0/0",
+    error
+);
+
+if (filecoin_signer_error_code(error) != 0) {
+    let err = String(cString: filecoin_signer_error_message(error)!);
+    fputs(err, stderr)
+}
+else {
+    let private_key = filecoin_signer_extended_key_private_key(extended_key);
+    assert(String(cString: private_key!) == "f15716d3b003b304b8055d9cc62e6b9c869d56cc930c3858d4d7c31f5f53f14a");
+    filecoin_signer_string_free(private_key);
+}
+
+filecoin_signer_extended_key_free(extended_key);
+filecoin_signer_error_free(error);


### PR DESCRIPTION
Depends on #111.

* De-duplicate some redundancies around the several language scripts.

* Add Swift example alongside CI support. It is unfortunate that many Linux distributions don't have repo support for Swift, requiring manual steps for installation.