### PR TITLE
Added send_sign rpc call

### DIFF
--- a/examples/service_jsonrpc/tests/basic.ispec.js
+++ b/examples/service_jsonrpc/tests/basic.ispec.js
@@ -376,3 +376,42 @@ test("send_sign", async () => {
 
   expect(response).toHaveProperty("result");
 });
+
+test("send_sign wrong network", async () => {
+  const path = "m/44'/461'/0/0/0";
+  const keyAddressResponse = await callMethod(URL, "key_derive", [EXPECTED_MNEMONIC, path], 1);
+
+  console.log(keyAddressResponse);
+
+  // Get Nonce
+  const nonceResponse = await callMethod(URL, "get_nonce", [keyAddressResponse.result.address], 1);
+
+  console.log("-----------------------------------------------------------------------------------");
+  let nonce = nonceResponse.result;
+  nonce++;
+  console.log("Nonce: ", nonce);
+
+  const transaction = {
+    to: "f17uoq6tp427uzv7fztkbsnn64iwotfrristwpryy",
+    from: "f" + keyAddressResponse.result.address.slice(1),
+    nonce: nonce,
+    value: "1",
+    gasprice: "0",
+    gaslimit: "1000000",
+    method: 0,
+    params: "",
+  };
+
+  console.log("-----------------------------------------------------------------------------------");
+
+  const response = await callMethod(
+    URL,
+    "send_sign",
+    [transaction, keyAddressResponse.result.private_hexstring],
+    2,
+  );
+
+  console.log("error: ", response);
+
+  expect(response).toHaveProperty("error");
+});

--- a/examples/service_jsonrpc/tests/basic.ispec.js
+++ b/examples/service_jsonrpc/tests/basic.ispec.js
@@ -338,7 +338,7 @@ test.skip("send_signed_tx", async () => {
   expect(response).toHaveProperty("result");
 });
 
-test("send_sign", async () => {
+test.skip("send_sign", async () => {
   const path = "m/44'/461'/0/0/0";
   const keyAddressResponse = await callMethod(URL, "key_derive", [EXPECTED_MNEMONIC, path], 1);
 
@@ -358,7 +358,7 @@ test("send_sign", async () => {
     nonce: nonce,
     value: "1",
     gasprice: "0",
-    gaslimit: "1000000",
+    gaslimit: 1000000,
     method: 0,
     params: "",
   };

--- a/examples/service_jsonrpc/tests/basic.ispec.js
+++ b/examples/service_jsonrpc/tests/basic.ispec.js
@@ -337,3 +337,42 @@ test.skip("send_signed_tx", async () => {
 
   expect(response).toHaveProperty("result");
 });
+
+test("send_sign", async () => {
+  const path = "m/44'/461'/0/0/0";
+  const keyAddressResponse = await callMethod(URL, "key_derive", [EXPECTED_MNEMONIC, path], 1);
+
+  console.log(keyAddressResponse);
+
+  // Get Nonce
+  const nonceResponse = await callMethod(URL, "get_nonce", [keyAddressResponse.result.address], 1);
+
+  console.log("-----------------------------------------------------------------------------------");
+  let nonce = nonceResponse.result;
+  nonce++;
+  console.log("Nonce: ", nonce);
+
+  const transaction = {
+    to: "t17uoq6tp427uzv7fztkbsnn64iwotfrristwpryy",
+    from: keyAddressResponse.result.address,
+    nonce: nonce,
+    value: "1",
+    gasprice: "0",
+    gaslimit: "1000000",
+    method: 0,
+    params: "",
+  };
+
+  console.log("-----------------------------------------------------------------------------------");
+
+  const response = await callMethod(
+    URL,
+    "send_sign",
+    [transaction, keyAddressResponse.result.private_hexstring],
+    2,
+  );
+
+  console.log("cidHash: ", response);
+
+  expect(response).toHaveProperty("result");
+});

--- a/service/src/service/client.rs
+++ b/service/src/service/client.rs
@@ -61,12 +61,6 @@ pub async fn get_nonce(url: &str, jwt: &str, addr: &str) -> Result<u64, ServiceE
     Ok(nonce)
 }
 
-/*pub async fn is_mainnet(_url: &str, _jwt: &str) -> Result<bool, ServiceError> {
-    // FIXME: Check if the node behind the url is running mainnet or not
-    // FIXME: https://github.com/Zondax/filecoin-rs/issues/32
-    Err(ServiceError::NotImplemented)
-}*/
-
 pub async fn send_signed_tx(url: &str, jwt: &str, signed_tx: Value) -> Result<Value, ServiceError> {
     let call_id = CALL_ID.fetch_add(1, Ordering::SeqCst);
 

--- a/service/src/service/client.rs
+++ b/service/src/service/client.rs
@@ -4,8 +4,10 @@ use crate::service::cache::{cache_get_nonce, cache_put_nonce};
 use crate::service::error::RemoteNode::{EmptyNonce, InvalidNonce, InvalidStatusRequest, JSONRPC};
 use crate::service::error::ServiceError;
 use abscissa_core::tracing::info;
+use filecoin_signer::api::UnsignedMessageAPI;
 use jsonrpc_core::response::Output::{Failure, Success};
 use jsonrpc_core::{Id, MethodCall, Params, Response, Version};
+use serde_json::json;
 use serde_json::value::Value;
 use std::sync::atomic::{AtomicU64, Ordering};
 
@@ -59,11 +61,11 @@ pub async fn get_nonce(url: &str, jwt: &str, addr: &str) -> Result<u64, ServiceE
     Ok(nonce)
 }
 
-pub async fn is_mainnet(_url: &str, _jwt: &str) -> Result<bool, ServiceError> {
+/*pub async fn is_mainnet(_url: &str, _jwt: &str) -> Result<bool, ServiceError> {
     // FIXME: Check if the node behind the url is running mainnet or not
     // FIXME: https://github.com/Zondax/filecoin-rs/issues/32
     Err(ServiceError::NotImplemented)
-}
+}*/
 
 pub async fn send_signed_tx(url: &str, jwt: &str, signed_tx: Value) -> Result<Value, ServiceError> {
     let call_id = CALL_ID.fetch_add(1, Ordering::SeqCst);
@@ -142,9 +144,38 @@ pub async fn get_balance(url: &str, jwt: &str, addr: &str) -> Result<Value, Serv
     Ok(balance)
 }
 
+pub async fn is_mainnet(url: &str, jwt: &str) -> Result<bool, ServiceError> {
+    let call_id = CALL_ID.fetch_add(1, Ordering::SeqCst);
+
+    let params = Params::Array(vec![
+        json!({"/": "bafy2bzacea2ob4bctlucgp2okbczqvk5ctx4jqjapslz57mbcmnnzyftgeqgu" }),
+    ]);
+
+    // Prepare request
+    let m = MethodCall {
+        jsonrpc: Some(Version::V2),
+        method: "Filecoin.ChainGetMessage".to_owned(),
+        params,
+        id: Id::Num(call_id),
+    };
+
+    let resp = make_rpc_call(url, jwt, &m).await?;
+
+    // Handle response
+    let message = match resp {
+        Response::Single(Success(s)) => s.result,
+        Response::Single(Failure(f)) => return Err(ServiceError::RemoteNode(JSONRPC(f.error))),
+        _ => return Err(ServiceError::RemoteNode(InvalidStatusRequest)),
+    };
+
+    let from_field = message.get("From").unwrap().as_str().unwrap();
+
+    Ok(from_field.starts_with("f"))
+}
+
 #[cfg(test)]
 mod tests {
-    use crate::service::client::{get_nonce, get_status};
+    use crate::service::client::{get_nonce, get_status, is_mainnet};
     use crate::service::test_helper::tests;
 
     use jsonrpc_core::types::error::{Error, ErrorCode};
@@ -156,6 +187,16 @@ mod tests {
         let data = b"{\"jsonrpc\":\"2.0\",\"id\":1,\"error\":{\"code\":1,\"message\":\"cbor input had wrong number of fields\"}}\n";
 
         let _err: Response = serde_json::from_slice(data).unwrap();
+    }
+
+    #[tokio::test]
+    async fn is_mainnet_test() {
+        let credentials = tests::get_remote_credentials();
+        let result = is_mainnet(&credentials.url, &credentials.jwt).await;
+
+        println!("{:?}", result);
+
+        assert!(result.is_ok());
     }
 
     #[tokio::test]

--- a/service/src/service/error.rs
+++ b/service/src/service/error.rs
@@ -22,6 +22,8 @@ pub enum RemoteNode {
 pub enum ServiceError {
     #[error("This is not yet implemented")]
     NotImplemented,
+    #[error("The network information provided in the tx doesn't match the node network.")]
+    WrongNetwork,
     /// JSONRPC error
     #[error("JSONRPC | {0}")]
     JSONRPC(#[from] jsonrpc_core::types::Error),

--- a/service/src/service/handlers.rs
+++ b/service/src/service/handlers.rs
@@ -45,6 +45,7 @@ async fn v0_post_methods(
         "get_status" => methods::get_status(method_call, config).await,
         "get_nonce" => methods::get_nonce(method_call, config).await,
         "send_signed_tx" => methods::send_signed_tx(method_call, config).await,
+        "send_sign" => methods::send_sign(method_call, config).await,
         _ => return Err(warp::reject::not_found()),
     };
 

--- a/service/src/service/methods.rs
+++ b/service/src/service/methods.rs
@@ -256,6 +256,28 @@ pub async fn send_signed_tx(
     Ok(so)
 }
 
+pub async fn send_sign(c: MethodCall, config: RemoteNodeSection) -> Result<Success, ServiceError> {
+    let params = c.params.parse::<SignTransactionParamsAPI>()?;
+
+    let private_key = PrivateKey::try_from(params.prvkey_hex)?;
+
+    // signed message
+    let signed_message = filecoin_signer::transaction_sign(&params.transaction, &private_key)?;
+
+    let signed_message_value = serde_json::to_value(&signed_message)?;
+
+    // send to remote node
+    let result = client::send_signed_tx(&config.url, &config.jwt, signed_message_value).await?;
+
+    let so = Success {
+        jsonrpc: Some(Version::V2),
+        result,
+        id: c.id,
+    };
+
+    Ok(so)
+}
+
 #[cfg(test)]
 mod tests {
     use crate::config::RemoteNodeSection;

--- a/service/src/service/methods.rs
+++ b/service/src/service/methods.rs
@@ -264,6 +264,9 @@ pub async fn send_sign(c: MethodCall, config: RemoteNodeSection) -> Result<Succe
     // signed message
     let signed_message = filecoin_signer::transaction_sign(&params.transaction, &private_key)?;
 
+    // FIXME: hack to verify node network
+    let result = client::get_balance(&config.url, &config.jwt, &params.transaction.from).await?;
+
     let signed_message_value = serde_json::to_value(&signed_message)?;
 
     // send to remote node


### PR DESCRIPTION
closes https://github.com/Zondax/filecoin-rs/issues/60

- [x] `send_sign` rpc call;
- [x] Added jsonrpc test case;
- [x] Reject different network transaction;

I believe we need to detect the node network because signed message doesn't have a network parameter and will just be accepted by the node. In order to complete this PR we need to solve this issue #32 first.