### PR TITLE
workaround for the incorrect package.json generated

### DIFF
--- a/signer-wasm/Makefile
+++ b/signer-wasm/Makefile
@@ -1,2 +1,3 @@
 build:
 	cp package-signer-wasm.json pkg/package.json
+	cp package-signer-wasm-browser.json pkg/browser/package.json

--- a/signer-wasm/package-signer-wasm-browser.json
+++ b/signer-wasm/package-signer-wasm-browser.json
@@ -1,0 +1,20 @@
+{
+  "name": "filecoin-signer-wasm",
+  "collaborators": [
+    "Zondax <info@zondax.ch>"
+  ],
+  "description": "",
+  "version": "0.1.0",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Zondax/filecoin-rs"
+  },
+  "files": [
+    "filecoin_signer_wasm_bg.wasm",
+    "filecoin_signer_wasm.js",
+    "filecoin_signer_wasm_bg.js"
+  ],
+  "module": "filecoin_signer_wasm.js",
+  "sideEffects": "false"
+}


### PR DESCRIPTION
It seems that wasm-bindgen generated an incorrect package.json (with a file not listed). So I copy a correct one.

I have created an issue https://github.com/rustwasm/wasm-bindgen/issues/2170 

I hope it will be fixed so we can removed this.