### PR TITLE
Purejs incompatibilities for browser

### DIFF
--- a/examples/private_keys_base64.txt
+++ b/examples/private_keys_base64.txt
@@ -1,0 +1,2 @@
+8VcW07ADswS4BV2cxi5rnIadVsyTDDhY1NfDH19T8Uo=
+YbDPh1vq3fBClzbiwDt6WjniAdZn8tNcCwcBO2hDwyk=

--- a/examples/wasm_browser/index.js
+++ b/examples/wasm_browser/index.js
@@ -1,4 +1,4 @@
-import * as wasm from "@zondax/filecoin-signer-wasm";
+import * as wasm from "@zondax/filecoin-signer/js";
 import TransportU2F from "@ledgerhq/hw-transport-u2f";
 import TransportWebUSB from "@ledgerhq/hw-transport-webusb";
 

--- a/examples/wasm_node/multisig_test.txt
+++ b/examples/wasm_node/multisig_test.txt
@@ -1,0 +1,22 @@
+{
+  "From" : "t3qc7jyphnl4ofu3tuwxkmqjw2zklnejnwkuxdcxpfw47wesf3ixcbdurzuznkg2tvdms37co4kieioqygnnpq",
+  "Method" : 2,
+  "To" : "t01",
+  "GasLimit" : 1000000,
+  "Nonce" : 1,
+  "Params" : "gtgqUwABVQAOZmlsLzEvbXVsdGlzaWdYMIOCVQH9HQ9N/Nfpmvy5moMmt9xFnTLGKFUBHq8ciku/7rCHCxdFsfV1A0cLcRYBAA==",
+  "Version" : 0,
+  "Value" : "10000",
+  "GasPrice" : "0"
+}
+
+
+# Look up ID
+{
+   "id" : 3,
+   "result" : "t0100",
+   "jsonrpc" : "2.0"
+}
+
+# Why t01001 ?????
+curl -X POST --header "Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJBbGxvdyI6WyJyZWFkIiwid3JpdGUiLCJzaWduIiwiYWRtaW4iXX0.0kBnsrfa3MeK3NWVD1m5io5MRBO8eoeQvCtQr4izdpM" --header "Content-Type: application/json" --data '{ "jsonrpc": "2.0", "method": "Filecoin.MsigGetAvailableBalance", "params": ["t01001", null], "id": 3 }' 'http://127.0.0.1:1234/rpc/v0' | json_pp

--- a/signer-wasm/js/package.json
+++ b/signer-wasm/js/package.json
@@ -10,10 +10,10 @@
   "dependencies": {
     "base32-decode": "^1.0.0",
     "base32-encode": "^1.1.1",
-    "bignum": "^0.13.1",
     "bip32": "^2.0.5",
     "bip39": "^3.0.2",
     "blakejs": "^1.1.0",
+    "bn.js": "^5.1.2",
     "ipld-dag-cbor": "^0.15.3",
     "secp256k1": "^4.0.1"
   },

--- a/signer-wasm/js/package.json
+++ b/signer-wasm/js/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "base32-decode": "^1.0.0",
     "base32-encode": "^1.1.1",
+    "bignum": "^0.13.1",
     "bip32": "^2.0.5",
     "bip39": "^3.0.2",
     "blakejs": "^1.1.0",
@@ -19,8 +20,8 @@
   "devDependencies": {
     "eslint": "^7.2.0",
     "eslint-config-prettier": "^6.11.0",
-    "eslint-plugin-prettier": "^3.1.4",
     "eslint-plugin-import": "^2.21.2",
+    "eslint-plugin-prettier": "^3.1.4",
     "mocha": "^7.2.0",
     "prettier": "^2.0.5"
   },

--- a/signer-wasm/js/src/utils.js
+++ b/signer-wasm/js/src/utils.js
@@ -16,7 +16,7 @@ const CID_PREFIX = Buffer.from([0x01, 0x71, 0xa0, 0xe4, 0x02, 0x20]);
 function getCID(message) {
   const blakeCtx = blake.blake2bInit(32);
   blake.blake2bUpdate(blakeCtx, message);
-  const hash = blake.blake2bFinal(blakeCtx);
+  const hash = Buffer.from(blake.blake2bFinal(blakeCtx));
   return Buffer.concat([CID_PREFIX, hash]);
 }
 
@@ -25,20 +25,20 @@ function getDigest(message) {
 
   const blakeCtx = blake.blake2bInit(32);
   blake.blake2bUpdate(blakeCtx, getCID(message));
-  return blake.blake2bFinal(blakeCtx);
+  return Buffer.from(blake.blake2bFinal(blakeCtx));
 }
 
 function getPayloadSECP256K1(uncompressedPublicKey) {
   // blake2b-160
   const blakeCtx = blake.blake2bInit(20);
   blake.blake2bUpdate(blakeCtx, uncompressedPublicKey);
-  return blake.blake2bFinal(blakeCtx);
+  return Buffer.from(blake.blake2bFinal(blakeCtx));
 }
 
 function getChecksum(payload) {
   const blakeCtx = blake.blake2bInit(4);
   blake.blake2bUpdate(blakeCtx, payload);
-  return blake.blake2bFinal(blakeCtx);
+  return Buffer.from(blake.blake2bFinal(blakeCtx));
 }
 
 function getAccountFromPath(path) {

--- a/signer-wasm/js/src/utils.js
+++ b/signer-wasm/js/src/utils.js
@@ -127,16 +127,6 @@ function bytesToAddress(payload, testnet) {
   );
 }
 
-function trimBuffer(buf) {
-  let indexStart = 0;
-  for (let i = 0; i < buf.length; i += 1) {
-    if (buf[i] === 0x00) {
-      indexStart += 1;
-    }
-  }
-  return buf.slice(indexStart - 1);
-}
-
 function tryToPrivateKeyBuffer(privateKey) {
   if (typeof privateKey === "string") {
     // We should have a padding!
@@ -160,6 +150,5 @@ module.exports = {
   getAccountFromPath,
   addressAsBytes,
   bytesToAddress,
-  trimBuffer,
   tryToPrivateKeyBuffer,
 };

--- a/signer-wasm/js/yarn.lock
+++ b/signer-wasm/js/yarn.lock
@@ -167,15 +167,6 @@ base64-js@^1.0.2:
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.3.1.tgz#58ece8cb75dd07e71ed08c736abc5fac4dbf8df1"
   integrity sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==
 
-bignum@^0.13.1:
-  version "0.13.1"
-  resolved "https://registry.yarnpkg.com/bignum/-/bignum-0.13.1.tgz#98b89297f343f50ba0a7d6a148e037cd37db751d"
-  integrity sha512-sPtvw/knt6nmBm4fPgsu+FtNypM5y2Org723h9fAOl7UDgc8nyIbVbcBCatVR/nOJWCsKctSE14u+3bW5sAkFA==
-  dependencies:
-    bindings "^1.5.0"
-    nan "^2.14.0"
-    safe-buffer "^5.2.0"
-
 bignumber.js@^9.0.0:
   version "9.0.0"
   resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-9.0.0.tgz#805880f84a329b5eac6e7cb6f8274b6d82bdf075"
@@ -186,7 +177,7 @@ binary-extensions@^2.0.0:
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.0.0.tgz#23c0df14f6a88077f5f986c0d167ec03c3d5537c"
   integrity sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow==
 
-bindings@^1.3.0, bindings@^1.5.0:
+bindings@^1.3.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/bindings/-/bindings-1.5.0.tgz#10353c9e945334bc0511a6d90b38fbc7c9c504df"
   integrity sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==
@@ -225,6 +216,11 @@ bn.js@^4.11.8, bn.js@^4.4.0:
   version "4.11.9"
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.11.9.tgz#26d556829458f9d1e81fc48952493d0ba3507828"
   integrity sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw==
+
+bn.js@^5.1.2:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-5.1.2.tgz#c9686902d3c9a27729f43ab10f9d79c2004da7b0"
+  integrity sha512-40rZaf3bUNKTVYu9sIeeEGOg7g14Yvnj9kH7b50EiwX0Q7A6umbvfI5tvHaOERH0XigqKkfLkFQxzb4e6CIXnA==
 
 borc@^2.1.2:
   version "2.1.2"
@@ -1286,7 +1282,7 @@ murmurhash3js-revisited@^3.0.0:
   resolved "https://registry.yarnpkg.com/murmurhash3js-revisited/-/murmurhash3js-revisited-3.0.0.tgz#6bd36e25de8f73394222adc6e41fa3fac08a5869"
   integrity sha512-/sF3ee6zvScXMb1XFJ8gDsSnY+X8PbOyjIuBhtgis10W2Jx4ZjIhikUCIF9c4gpJxVnQIsPAFrSwTCuAjicP6g==
 
-nan@^2.13.2, nan@^2.14.0:
+nan@^2.13.2:
   version "2.14.1"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.1.tgz#d7be34dfa3105b91494c3147089315eff8874b01"
   integrity sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==

--- a/signer-wasm/js/yarn.lock
+++ b/signer-wasm/js/yarn.lock
@@ -167,6 +167,15 @@ base64-js@^1.0.2:
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.3.1.tgz#58ece8cb75dd07e71ed08c736abc5fac4dbf8df1"
   integrity sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==
 
+bignum@^0.13.1:
+  version "0.13.1"
+  resolved "https://registry.yarnpkg.com/bignum/-/bignum-0.13.1.tgz#98b89297f343f50ba0a7d6a148e037cd37db751d"
+  integrity sha512-sPtvw/knt6nmBm4fPgsu+FtNypM5y2Org723h9fAOl7UDgc8nyIbVbcBCatVR/nOJWCsKctSE14u+3bW5sAkFA==
+  dependencies:
+    bindings "^1.5.0"
+    nan "^2.14.0"
+    safe-buffer "^5.2.0"
+
 bignumber.js@^9.0.0:
   version "9.0.0"
   resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-9.0.0.tgz#805880f84a329b5eac6e7cb6f8274b6d82bdf075"
@@ -177,7 +186,7 @@ binary-extensions@^2.0.0:
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.0.0.tgz#23c0df14f6a88077f5f986c0d167ec03c3d5537c"
   integrity sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow==
 
-bindings@^1.3.0:
+bindings@^1.3.0, bindings@^1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/bindings/-/bindings-1.5.0.tgz#10353c9e945334bc0511a6d90b38fbc7c9c504df"
   integrity sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==
@@ -1277,7 +1286,7 @@ murmurhash3js-revisited@^3.0.0:
   resolved "https://registry.yarnpkg.com/murmurhash3js-revisited/-/murmurhash3js-revisited-3.0.0.tgz#6bd36e25de8f73394222adc6e41fa3fac08a5869"
   integrity sha512-/sF3ee6zvScXMb1XFJ8gDsSnY+X8PbOyjIuBhtgis10W2Jx4ZjIhikUCIF9c4gpJxVnQIsPAFrSwTCuAjicP6g==
 
-nan@^2.13.2:
+nan@^2.13.2, nan@^2.14.0:
   version "2.14.1"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.1.tgz#d7be34dfa3105b91494c3147089315eff8874b01"
   integrity sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==


### PR DESCRIPTION
Issue raised in slack:
```
Hi everybody, even though initially pure-js lib did compile inside SES environment, we did spot a few problems when running lib inside snap itself.

1. index.js -> inside the function transactionSerializeRaw you use writeBigUInt64B function which is not supported in the browser.
 2. when ExtendedKey constructor is called with privateKey as Buffer, secp256k1 fails with privateKey must be Uint8Array
```
- [x] Replace  `writeBigUInt64B` with a browser compatible lib;
- [x] Issue with `tryToPrivateKeyBuffer` (need a bit more info)