### PR TITLE
Support serializeParams

### DIFF
--- a/docs/wasm/api.md
+++ b/docs/wasm/api.md
@@ -379,3 +379,27 @@ let approve_multisig_transaction = filecoin_signer.cancelMultisig("t01", 1234, p
 
 console.log(approve_multisig_transaction);
 ```
+
+## serializeParams
+
+Serialize parameters into cbor data.
+
+Arguments :
+* **params**: params object;
+
+```javascript
+const signer_wasm = require('@zondax/filecoin-signer');
+// or for browser
+// import * as signer_wasm from "@zondax/filecoin-signer";
+
+let addresses = ["t17uoq6tp427uzv7fztkbsnn64iwotfrristwpryy","t1d2xrzcslx7xlbbylc5c3d5lvandqw4iwl6epxba"];
+
+let params = {
+    code_cid: 'fil/1/multisig',
+    constructor_params: { signers: addresses, num_approvals_threshold: 1 }
+}
+
+let serialized_params = filecoin_signer.serializeParams(params);
+
+console.log(serialized_params);
+```

--- a/examples/wasm_node/test/tests.js
+++ b/examples/wasm_node/test/tests.js
@@ -752,7 +752,7 @@ describeCall("cancelMultisig", function() {
 })
 
 describeCall('SerializeParams', function () {
-  it('serliaze parameters to cbor data', function () {
+  it('serialize parameters to cbor data', function () {
     let addresses = ["t17uoq6tp427uzv7fztkbsnn64iwotfrristwpryy","t1d2xrzcslx7xlbbylc5c3d5lvandqw4iwl6epxba"];
 
     let params = {

--- a/examples/wasm_node/test/tests.js
+++ b/examples/wasm_node/test/tests.js
@@ -751,6 +751,26 @@ describeCall("cancelMultisig", function() {
   });
 })
 
+describeCall('SerializeParams', function () {
+  it('serliaze parameters to cbor data', function () {
+    let addresses = ["t17uoq6tp427uzv7fztkbsnn64iwotfrristwpryy","t1d2xrzcslx7xlbbylc5c3d5lvandqw4iwl6epxba"];
+
+    let params = {
+        code_cid: 'fil/1/multisig',
+        constructor_params: { signers: addresses, num_approvals_threshold: 1 }
+    }
+
+    let serialized_params = filecoin_signer.serializeParams(params);
+
+    console.log(Buffer.from(serialized_params).toString('hex'));
+
+    assert.strictEqual(
+      "82d82a53000155000e66696c2f312f6d756c7469736967583083825501fd1d0f4dfcd7e99afcb99a8326b7dc459d32c62855011eaf1c8a4bbfeeb0870b1745b1f57503470b71160100",
+      Buffer.from(serialized_params).toString('hex')
+    )
+  })
+})
+
 /* ------------------------------------------------------------------------------------------------- */
 
 const bls_tests_vectors_path = "../generated_test_cases.json";

--- a/signer-wasm/src/lib.rs
+++ b/signer-wasm/src/lib.rs
@@ -8,7 +8,7 @@
     )
 )]
 
-use filecoin_signer::api::UnsignedMessageAPI;
+use filecoin_signer::api::{MessageParams, UnsignedMessageAPI};
 use filecoin_signer::signature::Signature;
 use filecoin_signer::{CborBuffer, PrivateKey};
 use std::convert::TryFrom;
@@ -427,6 +427,20 @@ pub fn cancel_multisig(
         .map_err(|e| JsValue::from(format!("Error canceling transaction: {}", e)))?;
 
     Ok(multisig_transaction_js)
+}
+
+#[wasm_bindgen(js_name = serializeParams)]
+pub fn serialize_params(params_value: JsValue) -> Result<Vec<u8>, JsValue> {
+    set_panic_hook();
+
+    let params: MessageParams = params_value
+        .into_serde()
+        .map_err(|e| JsValue::from(format!("Error parsing parameters: {}", e)))?;
+
+    let params_cbor = filecoin_signer::serialize_params(params)
+        .map_err(|e| JsValue::from(format!("Error parsing parameters: {}", e)))?;
+
+    Ok(params_cbor.as_ref().to_vec())
 }
 
 #[cfg(target_arch = "wasm32")]

--- a/signer/src/api.rs
+++ b/signer/src/api.rs
@@ -76,6 +76,12 @@ impl TryFrom<MessageParamsMultisig> for ExecParams {
             forest_vm::Serialized::serialize::<ConstructorParams>(constructor_multisig_params)
                 .map_err(|err| SignerError::GenericString(err.to_string()))?;
 
+        if exec_constructor.code_cid != "fil/1/multisig" {
+            return Err(SignerError::GenericString(
+                "Only support `fil/1/multisig` code for now.",
+            ));
+        }
+
         Ok(ExecParams {
             code_cid: Cid::new_v1(Codec::Raw, Identity::digest(b"fil/1/multisig")),
             constructor_params: serialized_constructor_multisig_params,

--- a/signer/src/api.rs
+++ b/signer/src/api.rs
@@ -76,9 +76,9 @@ impl TryFrom<MessageParamsMultisig> for ExecParams {
             forest_vm::Serialized::serialize::<ConstructorParams>(constructor_multisig_params)
                 .map_err(|err| SignerError::GenericString(err.to_string()))?;
 
-        if exec_constructor.code_cid != "fil/1/multisig" {
+        if exec_constructor.code_cid != "fil/1/multisig".to_string() {
             return Err(SignerError::GenericString(
-                "Only support `fil/1/multisig` code for now.",
+                "Only support `fil/1/multisig` code for now.".to_string(),
             ));
         }
 


### PR DESCRIPTION
Added `serializeParams` to wasm interface.

Also make sure we only support code_cid for multisig.